### PR TITLE
fixes to compile with esp-idf 5.2

### DIFF
--- a/pcf8575_pro/CMakeLists.txt
+++ b/pcf8575_pro/CMakeLists.txt
@@ -1,6 +1,6 @@
-set(app_src PCF.c)
+set(srcs PCF.c)
 set(pre_req log )
+set(include_dirs ".")
 idf_component_register(SRCS ${app_src}
-                    INCLUDE_DIRS "."
+                    INCLUDE_DIRS ${include_dirs}
                     REQUIRES ${pre_req})
-                    

--- a/pcf8575_pro/CMakeLists.txt
+++ b/pcf8575_pro/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(srcs PCF.c)
-set(pre_req log )
+set(app_src PCF.c pcf8575/pcf8575.c i2cdev/i2cdev.c)
+set(pre_req log driver)
 set(include_dirs ".")
 idf_component_register(SRCS ${app_src}
                     INCLUDE_DIRS ${include_dirs}

--- a/pcf8575_pro/PCF.c
+++ b/pcf8575_pro/PCF.c
@@ -15,8 +15,9 @@ esp_err_t pcf8575_initialize(pcf8575_t *pcf8575, i2c_port_t port, gpio_num_t sda
             return error_code;
         }
 }
-// Hàm khởi xóa khởi tạo 
+// Hàm khởi xóa khởi tạo
 esp_err_t pcf8575_deinitialize(pcf8575_t *pcf8575){
+    
     esp_err_t error_code = pcf8575_free_desc(pcf8575->dev);
     if(error_code != ESP_OK){
         ESP_LOGE(__func__,"pcf8575 deinitialize failed !");

--- a/pcf8575_pro/PCF.h
+++ b/pcf8575_pro/PCF.h
@@ -2,12 +2,12 @@
 #define __PCF8575_PRO_H__
 
 #include <stddef.h>
-#include <i2cdev.h>
+#include "i2cdev/i2cdev.h"
 #include <esp_err.h>
 #include "esp_log.h"
 #include "driver/gpio.h"
-#include "esp_idf_lib_helpers.h"
-#include "pcf8575.h"
+#include "esp_idf_lib_helpers/esp_idf_lib_helpers.h"
+#include "pcf8575/pcf8575.h"
 
 
 #ifdef __cplusplus

--- a/pcf8575_pro/i2cdev/i2cdev.h
+++ b/pcf8575_pro/i2cdev/i2cdev.h
@@ -39,7 +39,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <esp_err.h>
-#include <esp_idf_lib_helpers.h>
+#include <esp_idf_lib_helpers/esp_idf_lib_helpers.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/pcf8575_pro/pcf8575/pcf8575.c
+++ b/pcf8575_pro/pcf8575/pcf8575.c
@@ -31,14 +31,13 @@
  * MIT Licensed as described in the file LICENSE
  */
 #include <esp_err.h>
-#include <esp_idf_lib_helpers.h>
+#include <esp_idf_lib_helpers/esp_idf_lib_helpers.h>
 #include "pcf8575.h"
 
 #define I2C_FREQ_HZ 400000
 
 #define CHECK(x) do { esp_err_t __; if ((__ = x) != ESP_OK) return __; } while (0)
 #define CHECK_ARG(VAL) do { if (!(VAL)) return ESP_ERR_INVALID_ARG; } while (0)
-#define BV(x) (1 << (x))
 
 static esp_err_t read_port(i2c_dev_t *dev, uint16_t *val)
 {

--- a/pcf8575_pro/pcf8575/pcf8575.h
+++ b/pcf8575_pro/pcf8575/pcf8575.h
@@ -45,6 +45,8 @@ extern "C" {
 
 #define PCF8575_I2C_ADDR_BASE 0x20
 
+#define BV(x) (1 << (x))
+
 /**
  * @brief Initialize device descriptor
  *

--- a/pcf8575_pro/pcf8575/pcf8575.h
+++ b/pcf8575_pro/pcf8575/pcf8575.h
@@ -36,7 +36,7 @@
 #define __PCF8575_H__
 
 #include <stddef.h>
-#include <i2cdev.h>
+#include <i2cdev/i2cdev.h>
 #include <esp_err.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Attempts to fix #1. This pull request is not quite ready. Looks like I need to figure out how to incorporate the sub-directories into the cmake system, because idf.py menuconfig on the main project does not bring up the Kconfigs of those subdirs. Alternatively, these can be pulled up into the top level Kconfig etc. I'm not familiar with how to use the idf build system in advanced ways yet, but this fix is close.